### PR TITLE
Changed the options type for channel and role

### DIFF
--- a/SlashCommands/Utility/delete.js
+++ b/SlashCommands/Utility/delete.js
@@ -12,7 +12,7 @@ module.exports = {
                 {
                     name: 'channel',
                     description: 'Channel to delete',
-                    type: "STRING"
+                    type: "ROLE"
                 }
             ],
         },
@@ -24,7 +24,7 @@ module.exports = {
                 {
                     name: 'role',
                     description: 'Role to delete',
-                    type: "STRING"
+                    type: "ROLE"
                 }
             ]
         }


### PR DESCRIPTION
Changes the options type for channel and role so that you can get all the roles in the server and don't need to type out the role name as a string, you need to update the code a little bit from the string type