### PR TITLE
Fixes?

### DIFF
--- a/events/player/trackAdd.js
+++ b/events/player/trackAdd.js
@@ -8,6 +8,6 @@ module.exports = async(queue, track) => {
       .setDescription(`[${track.title}](${track.url}) ~ [${track.requestedBy.toString()}]`)
       .setColor(queue.guild.me.displayColor || "#00FFFF");
 
-    return queue.metadata.reply({ embeds: [embed], allowedMentions: { repliedUser: false } }).catch(console.error);
+    return queue.metadata.channel.send({ embeds: [embed], allowedMentions: { repliedUser: false } }).catch(console.error);
 
 };


### PR DESCRIPTION
i have my own repo using the source code but adding music to queue goes error and the repo owner told me to replace the "
    return queue.metadata.Reply({ embeds: [embed], allowedMentions: { repliedUser: false } }).catch(console.error);" with "
    return queue.metadata.channel.send({ embeds: [embed], allowedMentions: { repliedUser: false } }).catch(console.error);" hoping that simpleboy will pull this?